### PR TITLE
Allow for all(varnames %in% cd.names) to be ok

### DIFF
--- a/R/fmMethods.R
+++ b/R/fmMethods.R
@@ -74,7 +74,8 @@ predict.maxlikeFit <- function(object, newdata=NULL, ...) {
     formula <- object$call$formula
     varnames <- all.vars(formula)
 # reversed cd.names and varnames to allow for polynomials etc via I(), Roeland Kindt
-    if(!all(cd.names %in% varnames)) {
+# when interaction terms are not the problem but there are unused predictors then it should also work, Samuel Bosch
+    if(!all(cd.names %in% varnames) && !all(varnames %in% cd.names)) {
         if (is.null(newdata) == F) {
             stop("at least 1 covariate in the formula is not in new data")
         }else{


### PR DESCRIPTION
When more rasters where provided to maxlike then are used in the formula the prediction function should still work. This was not the case anymore as it was checked if all provided rasters/newdata where present in the formula. By adding a second clause checking for the inverse case I believe that the problem with interaction terms Roeland Kindt experienced and the problem reported to me by David Sabadin are both handled.